### PR TITLE
Fix bug where spinner isn't updated when button's frame is updated

### DIFF
--- a/Source/SpinerLayer.swift
+++ b/Source/SpinerLayer.swift
@@ -17,16 +17,11 @@ class SpinerLayer: CAShapeLayer {
         }
     }
     
-    init(frame:CGRect) {
+    init(frame: CGRect) {
         super.init() 
-        let radius:CGFloat = (frame.height / 2) * 0.5
-        self.frame = CGRect(x: 0, y: 0, width: frame.height, height: frame.height)
-        let center = CGPoint(x: frame.height / 2, y: bounds.center.y)
-        let startAngle = 0 - Double.pi/2
-        let endAngle = Double.pi * 2 - Double.pi/2
-        let clockwise: Bool = true
-        self.path = UIBezierPath(arcCenter: center, radius: radius, startAngle: CGFloat(startAngle), endAngle: CGFloat(endAngle), clockwise: clockwise).cgPath
 
+        self.setToFrame(frame)
+        
         self.fillColor = nil
         self.strokeColor = spinnerColor.cgColor
         self.lineWidth = 1
@@ -52,6 +47,16 @@ class SpinerLayer: CAShapeLayer {
         rotate.isRemovedOnCompletion = false
         self.add(rotate, forKey: rotate.keyPath)
 
+    }
+    
+    func setToFrame(_ frame: CGRect) {
+        let radius:CGFloat = (frame.height / 2) * 0.5
+        self.frame = CGRect(x: 0, y: 0, width: frame.height, height: frame.height)
+        let center = CGPoint(x: frame.height / 2, y: bounds.center.y)
+        let startAngle = 0 - Double.pi/2
+        let endAngle = Double.pi * 2 - Double.pi/2
+        let clockwise: Bool = true
+        self.path = UIBezierPath(arcCenter: center, radius: radius, startAngle: CGFloat(startAngle), endAngle: CGFloat(endAngle), clockwise: clockwise).cgPath
     }
     
     func stopAnimation() {

--- a/Source/TransitionButton.swift
+++ b/Source/TransitionButton.swift
@@ -75,6 +75,11 @@ open class TransitionButton : UIButton, UIViewControllerTransitioningDelegate, C
         self.setup()
     }
     
+    open override func layoutSubviews() {
+        super.layoutSubviews()
+        self.spiner.setToFrame(self.frame)
+    }
+    
     private func setup() {
         self.clipsToBounds  = true
         spiner.spinnerColor = spinnerColor


### PR DESCRIPTION
I found this bug when trying to create a TransitionButton with one rect, then added it to a stackView. The stackView updated the frame of the button, but the spinner's frame wasn't updated, causing it to become un-centered